### PR TITLE
Fix APP_TRAINING_MODE env import

### DIFF
--- a/medcat_service/nlp_processor/medcat_processor.py
+++ b/medcat_service/nlp_processor/medcat_processor.py
@@ -54,7 +54,10 @@ class MedCatProcessor(NlpProcessor):
         self.app_model = os.getenv("APP_MODEL_NAME", 'unknown')
 
         self.cat = self._create_cat()
-        self.cat.spacy_cat.train = os.getenv("APP_TRAINING_MODE", False)
+
+        self.cat.spacy_cat.train = False
+        if os.getenv("APP_TRAINING_MODE") == "True":
+            self.cat.spacy_cat.train = True
 
         self.bulk_nproc = int(os.getenv('APP_BULK_NPROC', 8))
 


### PR DESCRIPTION
Hi @lrog with help from @w-is-h I noticed that when `APP_TRAINING_MODE` was set to anything, ` self.cat.spacy_cat.train ` was always `True`, because it's a string not a boolean :)