### PR TITLE
Added medcat requirements.txt packages as individual dependencies to fix tokenizer and torch errors

### DIFF
--- a/medcat_service/requirements.txt
+++ b/medcat_service/requirements.txt
@@ -1,4 +1,10 @@
 medcat~=0.3
+gensim~=3.7
+scipy~=1.4
+tokenizers~=0.8.0
+spacy==2.2.4
+torch~=1.4.0
+torchvision~=0.5.0
 Flask==1.1.1
 simplejson==3.17.0
 gunicorn==20.0.4


### PR DESCRIPTION
Updated to address tokenizer error when tried to deploy MedCAT service locally and ran curl example in README (which seems to have been picked up last week in MedCAT separately).
After adding this, additional errors flagged pytorch as not available which I'd assumed should've been loaded through medcat. 
Added all medcat dependencies explicitly to be comprehensive.

