### PR TITLE
Fix model pack

### DIFF
--- a/medcat_service/api/api.py
+++ b/medcat_service/api/api.py
@@ -48,7 +48,7 @@ def process(nlp_service: NlpService) -> Response:
         result = nlp_service.nlp.process_content(payload['content'])
         app_info = nlp_service.nlp.get_app_info()
         response = {'result': result, 'medcat_info': app_info}
-        return Response(response=json.dumps(response), status=200, mimetype="application/json")
+        return Response(response=json.dumps(response, iterable_as_array=True), status=200, mimetype="application/json")
 
     except Exception as e:
         log.error(traceback.format_exc())

--- a/medcat_service/nlp_processor/medcat_processor.py
+++ b/medcat_service/nlp_processor/medcat_processor.py
@@ -205,9 +205,9 @@ class MedCatProcessor(NlpProcessor):
 
         model_pack_path = os.getenv("APP_MEDCAT_MODEL_PACK", "").strip()
         if model_pack_path != "":
+            self.log.info("Loading model pack...")
             cat = CAT.load_model_pack(model_pack_path)
-            cdb = cat.cdb
-            config = cat.config
+            return cat
         else:
             self.log.info("APP_MEDCAT_MODEL_PACK not set, skipping....")
 

--- a/medcat_service/requirements.txt
+++ b/medcat_service/requirements.txt
@@ -2,9 +2,7 @@ Flask==2.0.2
 gunicorn==20.1.0
 injector==0.18.4
 flask-injector==0.13.0
-medcat==1.2.8
+medcat==1.3.0
 setuptools~=58.5.3
 simplejson~=3.17.5
-spacy==3.1.3
-click<=8.0.4
 werkzeug==2.0.3


### PR DESCRIPTION
- In a previous PR, in `json.dumps` `iterable_as_array=True` was added for bulk requests. This PR also adds it for non-bulk requests.
- Bumb MedCAT version to v1.3.0
- Remove libraries from requirements that are already defined in MedCAT. I hope that's okay, it could save the next person time by not having to check version numbers.
- I had an issue where I specified the model pack, but it errored on searching for vocab. I think loading cdb, vocab, config and metacats should not be necessary when model pack is provided, is this also how you intended the design?

The only functionality still missing from loading model pack, is using `APP_MODEL_CUI_FILTER_PATH`. Since this changes the CDB, it would be nice to incorporate `cdb.filter_by_cui(selected_cuis)` within MedCAT's `load_model_pack`-function, somewhere after this line: https://github.com/CogStack/MedCAT/blob/60b047f701ad21441c74149fc52aa51baa4f7b72/medcat/cat.py#L296
and when that is implement, MedCATservice can make use of that functionality.

I ran the bulk, non-bulk and /info API calls, and they all returned successfully.