### PR TITLE
Use a build-time variable for configuring spaCy models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,8 @@ RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 # Get the spacy model
-
-RUN python -m spacy download en_core_web_sm
-RUN python -m spacy download en_core_web_md
-RUN python -m spacy download en_core_web_lg
-
-#RUN pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.4.0/en_core_sci_md-0.4.0.tar.gz
-#RUN pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.4.0/en_core_sci_lg-0.4.0.tar.gz
+ARG SPACY_MODELS="en_core_web_sm en_core_web_md en_core_web_lg"
+RUN for spacy_model in ${SPACY_MODELS}; do python -m spacy download $spacy_model; done
 
 # Copy the remaining files
 COPY . /cat

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ In the current implementation, configuration for both MedCAT Service application
 
 Both files allow tailoring MedCAT for specific use-cases. When running MedCAT Service, these variables need to be loaded into the current working environment.
 
+## spaCy models
+When using MedCAT for a different language than English, it can be useful to use a different spaCy model. A spaCy model can be included in the MedCAT model pack, but when not using this functionality, it can be useful to install models in the Docker image. This can be done by setting a build-time variable. See the `SPACY_MODELS` variable in [Dockerfile](Dockerfile) for default value and usage.
+
 ## MedCAT Service
 MedCAT Service application are defined in `envs/env_app` file.
 


### PR DESCRIPTION
When using MedCAT for a different language than English, it can be useful to use a different spaCy model. A spaCy model can be included in the MedCAT model pack, but when not using this functionality, it can be useful to install models in the Docker image. This can be done by setting a build-time variable. See the `SPACY_MODELS` variable in [Dockerfile](Dockerfile) for default value and usage.

This PR adds:
- Functionality for setting the spaCy models in Dockerfile
- Documentation how to use this